### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ A formal documation is under development, but you may want to visit an auto-gene
 
 ## Example usage
 ```python
-import pandas as pd
 from omniplot import plot as op
 import seaborn as  sns
 import matplotlib.pyplot as plt
 
 df=sns.load_dataset("titanic")
-df=df[["class","embark_town","sex"]].fillna("NA")
-op.nested_piechart(df, category=["class","embark_town","sex"], title="Titanic", ignore=0.01, show_legend=True,show_values=False,hatch=True,ncols=3)
+df["class"]=df["class"].astype(str)
+df["embark_town"]=df["embark_town"].astype(str)
+op.nested_piechart(df, category=["class","embark_town","sex"], title="Titanic", ignore=0.01, show_legend=True,show_values=False,hatch=True)
 plt.show()
 
 ```


### PR DESCRIPTION
There are a few errors when I tried to run the example usage using python "3.12.4"

requirements:
        -i https://pypi.org/simple
        absl-py==2.1.0; python_version >= '3.7'
        adjusttext==1.2.0
        aiosignal==1.3.1; python_version >= '3.7'
        astunparse==1.6.3
        attrs==24.2.0; python_version >= '3.7'
        bioframe==0.7.2
        certifi==2024.7.4; python_version >= '3.6'
        charset-normalizer==3.3.2; python_full_version >= '3.7.0'
        click==8.1.7; python_version >= '3.7'
        cloudpickle==3.0.0; python_version >= '3.8'
        colorcet==3.1.0; python_version >= '3.7'
        contourpy==1.2.1; python_version >= '3.9'
        cvxopt==1.3.2; python_version >= '3' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
        cycler==0.12.1; python_version >= '3.8'
        dask==2024.8.1; python_version >= '3.10'
        datashader==0.16.3; python_version >= '3.9'
        fastcluster==1.2.6; python_version >= '3'
        filelock==3.15.4; python_version >= '3.8'
        flatbuffers==24.3.25
        fonttools==4.53.1; python_version >= '3.8'
        frozenlist==1.4.1; python_version >= '3.8'
        fsspec==2024.6.1; python_version >= '3.8'
        gast==0.6.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
        google-pasta==0.2.0
        grpcio==1.65.5; python_version >= '3.8'
        h5py==3.11.0; python_version >= '3.8'
        idna==3.7; python_version >= '3.5'
        igraph==0.11.6; python_version >= '3.8'
        imageio==2.35.0; python_version >= '3.8'
        intervaltree==3.1.0
        joblib==1.4.2; python_version >= '3.8'
        jsonschema==4.23.0; python_version >= '3.8'
        jsonschema-specifications==2023.12.1; python_version >= '3.8'
        keras==3.5.0; python_version >= '3.9'
        kiwisolver==1.4.5; python_version >= '3.7'
        lazy-loader==0.4; python_version >= '3.7'
        libclang==18.1.1
        llvmlite==0.43.0; python_version >= '3.9'
        locket==1.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
        markdown==3.7; python_version >= '3.8'
        markdown-it-py==3.0.0; python_version >= '3.8'
        markupsafe==2.1.5; python_version >= '3.7'
        matplotlib==3.9.2; python_version >= '3.9'
        mdurl==0.1.2; python_version >= '3.7'
        ml-dtypes==0.4.0; python_version >= '3.9'
        msgpack==1.0.8; python_version >= '3.8'
        multipledispatch==1.0.0
        namex==0.0.8
        natsort==8.4.0; python_version >= '3.7'
        ncls==0.0.68
        networkx==3.3; python_version >= '3.10'
        numba==0.60.0; python_version >= '3.9'
        numpy==1.26.4; python_version >= '3.9'
        omniplot@ git+https://github.com/koonimaru/omniplot.git@5cd309c3357a7286f837d457317d84126b42a155
        opt-einsum==3.3.0; python_version >= '3.5'
        optree==0.12.1; python_version >= '3.7'
        packaging==24.1; python_version >= '3.8'
        pandas==2.2.2; python_version >= '3.9'
        param==2.1.1; python_version >= '3.8'
        partd==1.4.2; python_version >= '3.9'
        patsy==0.5.6
        pillow==10.4.0; python_version >= '3.8'
        protobuf==4.25.4; python_version >= '3.8'
        pyct==0.5.0; python_version >= '3.7'
        pygments==2.18.0; python_version >= '3.8'
        pynndescent==0.5.13
        pyparsing==3.1.2; python_full_version >= '3.6.8'
        pyranges==0.1.2
        python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
        python-louvain==0.16
        pytz==2024.1
        pyyaml==6.0.2; python_version >= '3.8'
        ray==2.34.0; python_version >= '3.8'
        referencing==0.35.1; python_version >= '3.8'
        requests==2.32.3; python_version >= '3.8'
        rich==13.7.1; python_full_version >= '3.7.0'
        rpds-py==0.20.0; python_version >= '3.8'
        scikit-fuzzy==0.4.2
        scikit-image==0.24.0; python_version >= '3.9'
        scikit-learn==1.5.1; python_version >= '3.9'
        scipy==1.14.0; python_version >= '3.10'
        seaborn==0.13.2; python_version >= '3.8'
        setuptools==72.2.0; python_version >= '3.8'
        six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
        sorted-nearest==0.0.39
        sortedcontainers==2.4.0
        statsmodels==0.14.2; python_version >= '3.9'
        tabulate==0.9.0; python_version >= '3.7'
        tensorboard==2.17.1; python_version >= '3.9'
        tensorboard-data-server==0.7.2; python_version >= '3.7'
        tensorflow==2.17.0; python_version >= '3.9'
        termcolor==2.4.0; python_version >= '3.8'
        texttable==1.7.0
        threadpoolctl==3.5.0; python_version >= '3.8'
        tifffile==2024.8.10; python_version >= '3.9'
        toolz==0.12.1; python_version >= '3.7'
        tqdm==4.66.5; python_version >= '3.7'
        typing-extensions==4.12.2; python_version >= '3.8'
        tzdata==2024.1; python_version >= '2'
        umap-learn==0.5.6
        urllib3==2.2.2; python_version >= '3.8'
        werkzeug==3.0.3; python_version >= '3.8'
        wheel==0.44.0; python_version >= '3.8'
        wrapt==1.16.0; python_version >= '3.6'
        xarray==2024.7.0; python_version >= '3.9'
